### PR TITLE
Changed mustache template to use new cleaver slide input

### DIFF
--- a/template.mustache
+++ b/template.mustache
@@ -1,5 +1,5 @@
 {{#slides}}
   <section>
-    {{{.}}}
+    {{{content}}}
   </section>
 {{/slides}}


### PR DESCRIPTION
Hi @sudodoki,

Cleaver 0.6.0 changed the way it pipes slide data into templates, so instead of a list of strings, the "slides" array is a list of objects with an "id" and "content" field.

This PR fixes your theme to support this new style.
